### PR TITLE
Committee member key recovery

### DIFF
--- a/scripts/nouns/key_derivation.ts
+++ b/scripts/nouns/key_derivation.ts
@@ -1,0 +1,36 @@
+import { utils, Signer } from "ethers";
+import { arrayify } from "@ethersproject/bytes";
+
+
+/// Derive a secret from some other key in a deterministic way by signing a
+/// fixed message and using the resulting bytes.  The modulus is used to
+/// determine how many bytes to extract from the signature, as well as to
+/// reduce the secret into the appropriate field.
+export async function deriveSecret(
+  message: string,
+  signer: Signer,
+  modulus: bigint): Promise<{ secret: bigint, eth_pk: string }> {
+
+  // Compute required byte-length, rounded up to the nearest byte.
+  const max_value = modulus - BigInt(1);
+  const byte_length = ((max_value.toString(16).length + 1) / 2) | 0;
+
+  // Generate the signature, and extract enough (hex) bytes for the secret
+  // (i.e. leading '0x' + 2 chars per byte).
+  const char_length = 2 * (byte_length + 1);
+  let sig = await signer.signMessage(message);
+  if (!sig.startsWith("0x")) {
+    sig = "0x" + sig;
+  }
+
+  // Ensure sufficient data.
+  if (sig.length < char_length) {
+    throw "insufficient bytes in signature";
+  }
+
+  // Extract the public key
+  const msg_hash = utils.hashMessage(message);
+  const eth_pk = utils.recoverPublicKey(msg_hash, sig);
+
+  return { secret: BigInt(sig.slice(0, char_length)) % modulus, eth_pk };
+}

--- a/scripts/nouns/nouns.ts
+++ b/scripts/nouns/nouns.ts
@@ -9,7 +9,7 @@ import {
   Nouns__factory, Round2Verifier__factory, NvoteVerifier__factory, TallyVerifier__factory,
 } from "../types";
 import { Vote, Voter, VoteRecord } from "./voter";
-import { CommitteeMemberDKG } from "./committee_member";
+import { CommitteeMemberDKG, recoverCommitteeMember } from "./committee_member";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber } from "ethers";
 import { expect } from "chai";
@@ -77,6 +77,19 @@ async function main(
     async (signer, i) => CommitteeMemberDKG.initialize(
       babyjub, poseidon, dc_descriptor, zkv_descriptor, signer, i + 1)
   ));
+
+  // Attempt to reconstruct each members secrets.  This should return null at
+  // this stage.
+  await Promise.all(committee_dkg.map(async dkg_member => {
+    const member = await recoverCommitteeMember(
+      babyjub,
+      poseidon,
+      dc,
+      zkv,
+      dkg_member.signer,
+      dkg_member.getRound2SecretKey());
+    expect(member).to.be.null;
+  }));
 
   //
   // 1. Key Generation Round 1 (Committee)

--- a/scripts/nouns/nouns.ts
+++ b/scripts/nouns/nouns.ts
@@ -1,6 +1,6 @@
 import {
   PublicKey, pointFromSolidity, pointFromScalar, pointAdd, pointMul,
-  polynomial_evaluate_group,
+  polynomial_evaluate_group, groupOrder
 } from "../crypto";
 import * as nouns_contract from "./nouns_contract";
 import * as dkg_contract from "./dkg_contract";
@@ -9,7 +9,7 @@ import {
   Nouns__factory, Round2Verifier__factory, NvoteVerifier__factory, TallyVerifier__factory,
 } from "../types";
 import { Vote, Voter, VoteRecord } from "./voter";
-import { CommitteeMemberDKG, recoverCommitteeMember } from "./committee_member";
+import { CommitteeMemberDKG, deriveDKGSecret, recoverCommitteeMember } from "./committee_member";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { BigNumber } from "ethers";
 import { expect } from "chai";
@@ -61,7 +61,6 @@ async function main(
     10n, // total voting power
   );
 
-  const dummy_block_number_before_zkvote_deploy = 10;
   const zkv_descriptor = await zkvote_contract.get_descriptor(zkv, 10);
 
   // Deploy contract, and register voters
@@ -72,24 +71,32 @@ async function main(
 
   const nc_descriptor = await nouns_contract.get_descriptor(nc);
 
+  //
   // 0. Create committee members
+  //
+
   const committee_dkg: CommitteeMemberDKG[] = await Promise.all(COMMITEE.map(
-    async (signer, i) => CommitteeMemberDKG.initialize(
-      babyjub, poseidon, dc_descriptor, zkv_descriptor, signer, i + 1)
+    async (signer, i) => {
+      const a_0 = await deriveDKGSecret(babyjub, signer);
+      return await CommitteeMemberDKG.initialize(
+        babyjub, poseidon, dc_descriptor, zkv_descriptor, signer, i + 1, a_0)
+    }
   ));
 
-  // Attempt to reconstruct each members secrets.  This should return null at
-  // this stage.
-  await Promise.all(committee_dkg.map(async dkg_member => {
-    const member = await recoverCommitteeMember(
-      babyjub,
-      poseidon,
-      dc,
-      zkv,
-      dkg_member.signer,
-      dkg_member.getRound2SecretKey());
-    expect(member).to.be.null;
-  }));
+  {
+    // Attempt to reconstruct each members secrets.  This should return null at
+    // this stage.
+    await Promise.all(committee_dkg.map(async dkg_member => {
+      const member = await recoverCommitteeMember(
+        babyjub,
+        poseidon,
+        dc,
+        zkv,
+        dkg_member.signer,
+        dkg_member.getRound2SecretKey());
+      expect(member).to.be.null;
+    }));
+  }
 
   //
   // 1. Key Generation Round 1 (Committee)


### PR DESCRIPTION
- [x] split out the process to recover committee secret keys from DKG keys
- [x] make the DKG key selection deterministic (based on Ethereum secret key).  it was previously random, preventing recovery after the process terminated.
- [x] try to recover committee secret key at startup, falling back to DKG if that fails.

With these changes, the intention is that a committee node can be shut down after DKG has succeeded, and then restarted.  Since it should be using the same Eth secret key as during DKG, it can recover its committee key from the chain and participate in tallying again.
